### PR TITLE
Added operator chaining for openCL argument

### DIFF
--- a/OpenCL Simulation Code/clKernel.h
+++ b/OpenCL Simulation Code/clKernel.h
@@ -59,6 +59,9 @@ public:
 	clQueue* clq;
 
 	size_t kernelsize;
+
+	// for chainloading setArgT
+	int iter;
 	
 
 	//clKernel(const char* codestring, cl_context &context, cl_uint &numdevices, cl_device_id* &devices, std::string kernelname,cl_command_queue &commandQueue);
@@ -104,7 +107,25 @@ public:
 		}
 	}
 
-	// Operater chained for slightly cleaner openCL argument setting
+	// Operater method chaining for slightly cleaner openCL argument setting.
+	// MUST USE <= FIRST to set iterator to 0, then use <<
+	// Currently needs support for 'skipping' values when they do no need to be changed
+
+	template<typename T>
+	clKernel& operator<=(T value){
+		iter = 0;
+		SetArgT(iter,value);
+		iter++;
+		return *this;
+	}
+
+	// completely untested and a guess
+	template<typename T>
+	clKernel& operator<<(){
+		iter++;
+		return *this;
+	}
+
 	template<typename T>
 	clKernel& operator<<(T value){
 		SetArgT(iter,value);

--- a/OpenCL Simulation Code/clKernel.h
+++ b/OpenCL Simulation Code/clKernel.h
@@ -4,6 +4,10 @@
 #include <iostream>
 #include <vector>
 
+// define dummy type to overload template
+typedef bool dummy_CL;
+const dummy_CL CL_SKIP = false;
+
 enum clTypes
 {
 	clFloat = 0,
@@ -60,7 +64,7 @@ public:
 
 	size_t kernelsize;
 
-	// for chainloading setArgT
+	// for chaining setArgT
 	int iter;
 	
 
@@ -108,29 +112,27 @@ public:
 	}
 
 	// Operater method chaining for slightly cleaner openCL argument setting.
-	// MUST USE <= FIRST to set iterator to 0, then use <<
+	// MUST USE << FIRST to set iterator to 0, then use &&
 	// Currently needs support for 'skipping' values when they do no need to be changed
 
 	template<typename T>
-	clKernel& operator<=(T value){
+	clKernel& operator<<(T value){
 		iter = 0;
 		SetArgT(iter,value);
 		iter++;
 		return *this;
 	}
 
-	// completely untested and a guess
-	template<typename T>
-	clKernel& operator<<(){
+	// http://msdn.microsoft.com/en-us/library/kwyxac18.aspx
+	clKernel& operator&&(dummy_CL na){
 		iter++;
 		return *this;
 	}
 
 	template<typename T>
-	clKernel& operator<<(T value){
+	clKernel& operator&&(T value){
 		SetArgT(iter,value);
 		iter++;
 		return *this;
 	}
-
 };

--- a/OpenCL Simulation Code/clKernel.h
+++ b/OpenCL Simulation Code/clKernel.h
@@ -104,6 +104,12 @@ public:
 		}
 	}
 
-
+	// Operater chained for slightly cleaner openCL argument setting
+	template<typename T>
+	clKernel& operator<<(T value){
+		SetArgT(iter,value);
+		iter++;
+		return *this;
+	}
 
 };

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#clTEM - development branch
+#clTEM
 
 ####OpenCL TEM/STEM/Diffraction/EW image simulation software
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#clTEM
+#clTEM Jon Branch
 
 ####OpenCL TEM/STEM/Diffraction/EW image simulation software
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#clTEM Jon Branch
+#clTEM
 
 ####OpenCL TEM/STEM/Diffraction/EW image simulation software
 


### PR DESCRIPTION
Tested in separate project but not implemented here. Compatible with the terrible previous method of setting the openCL arguments.
