### PR TITLE
Occupancy

### DIFF
--- a/GPU TEM-STEM Simulation/MainWindow.xaml.cs
+++ b/GPU TEM-STEM Simulation/MainWindow.xaml.cs
@@ -400,7 +400,7 @@ namespace GPUTEMSTEMSimulation
                     mCL.GetNumberSlices(ref NumberOfSlices);
                     // Seperate into setup, loop over slices and final steps to allow for progress reporting.
 
-                    for (int i = 1; i <= NumberOfSlices; i++)
+                    for (int i = 1; i <= NumberOfSlices-20; i++)
                     {
                         timer.Start();
                         mCL.MultisliceStep(i, NumberOfSlices);

--- a/OpenCL Simulation Code/MultisliceStructure.cpp
+++ b/OpenCL Simulation Code/MultisliceStructure.cpp
@@ -25,8 +25,9 @@ void MultisliceStructure::CheckOcc(AtomOcc a, AtomOcc b)
 
 void MultisliceStructure::ImportAtoms(std::string filepath) {
 
-	std::ifstream inputFile(filepath,std::ifstream::in);
-	//inputFile.open(filename,ios::in);
+	//std::ifstream inputFile(filepath,std::ifstream::in);
+	std::ifstream inputFile;
+	inputFile.open(filepath,ios::in);
 	bool addatom = true;
 
 	Atom linebuffer;
@@ -39,13 +40,17 @@ void MultisliceStructure::ImportAtoms(std::string filepath) {
 
 	int numAtoms;
 	std::string commentline;
+	std::string commentline2;
 
 	// First two lines of .xyz, dont do anytihng with comment though
 	inputFile >> numAtoms;
-	inputFile >> commentline; // Will break if comment more than one word...
+	//inputFile >> commentline; // Will break if comment more than one word...
+	getline(inputFile, commentline);
+	getline(inputFile, commentline2); // Not sure why it reads this with second line?
+
 
 	// this branch is hardcoded to be nm for now
-	if(commentline=="occ")
+	if(commentline2=="occ")
 	{
 		for(int i=1; i<= numAtoms; i++) {
 			std::string atomSymbol;

--- a/OpenCL Simulation Code/MultisliceStructure.cpp
+++ b/OpenCL Simulation Code/MultisliceStructure.cpp
@@ -18,12 +18,20 @@ float MultisliceStructure::TDSRand()
 	return randNormal;
 };
 
+void MultisliceStructure::CheckOcc(AtomOcc a, AtomOcc b)
+{
+
+};
+
 void MultisliceStructure::ImportAtoms(std::string filepath) {
 
 	std::ifstream inputFile(filepath,std::ifstream::in);
 	//inputFile.open(filename,ios::in);
+	bool addatom = true;
 
 	Atom linebuffer;
+	AtomOcc thisAtom;
+	AtomOcc prevAtom;
 
 	if (!inputFile) {
 		// TODO: Do something if its gone really bad...
@@ -34,13 +42,60 @@ void MultisliceStructure::ImportAtoms(std::string filepath) {
 
 	// First two lines of .xyz, dont do anytihng with comment though
 	inputFile >> numAtoms;
-	getline(inputFile,commentline);
+	inputFile >> commentline; // Will break if comment more than one word...
 
-	for(int i=1; i<= numAtoms; i++) {
-		std::string atomSymbol;
-		inputFile >> atomSymbol >> linebuffer.x >> linebuffer.y >> linebuffer.z;
-		linebuffer.Z = GetZNum(atomSymbol);
-		Atoms.push_back (linebuffer);
+	// this branch is hardcoded to be nm for now
+	if(commentline=="occ")
+	{
+		for(int i=1; i<= numAtoms; i++) {
+			std::string atomSymbol;
+			inputFile >> atomSymbol >> thisAtom.x >> thisAtom.y >> thisAtom.z >> thisAtom.occ;
+			thisAtom.Z = GetZNum(atomSymbol);
+
+			// Check previous atom for same position.
+			if(thisAtom.occ != 1)
+			{
+				if(i!=1)
+				{
+					if(thisAtom.x ==prevAtom.x && thisAtom.y == prevAtom.y && thisAtom.z == prevAtom.z)
+					{
+						double r = ((double) rand() / (RAND_MAX));
+
+						if(r <= prevAtom.occ)
+						{
+							addatom=false;
+							; // Don't remove any atoms, don't add next atom;
+						}
+						else
+						{
+							Atoms.pop_back();
+						}
+					}
+				}
+			}
+
+			prevAtom = thisAtom;
+			if(addatom)
+			{
+				linebuffer.x = thisAtom.x * 10;
+				linebuffer.y = thisAtom.y * 10;
+				linebuffer.z = thisAtom.z * 10;
+				linebuffer.Z = thisAtom.Z;
+
+				Atoms.push_back (linebuffer);
+			}
+
+			addatom=true;
+		}
+	}
+	else
+	{
+		for(int i=1; i<= numAtoms; i++) {
+			std::string atomSymbol;
+			inputFile >> atomSymbol >> linebuffer.x >> linebuffer.y >> linebuffer.z;
+			linebuffer.Z = GetZNum(atomSymbol);
+			Atoms.push_back (linebuffer);
+		}
 	}
 
 	inputFile.close();

--- a/OpenCL Simulation Code/MultisliceStructure.h
+++ b/OpenCL Simulation Code/MultisliceStructure.h
@@ -17,6 +17,15 @@ struct Atom
 	float z;
 };
 
+struct AtomOcc
+{
+	int Z;
+	float x;
+	float y;
+	float z;
+	float occ;
+};
+
 using namespace std;
 
 class MultisliceStructure
@@ -56,6 +65,9 @@ public:
 
 	// Convert atomic symbol i.e. Fe to Atomic Number e.g. 53
 	static int GetZNum(std::string AtomSymbol);
+
+	// Check atoms for same position and remove one.
+	void CheckOcc(AtomOcc a, AtomOcc b);
 
 	std::vector<Atom> Atoms;
 


### PR DESCRIPTION
Can now use an occupancy column in xyz file if comment line is "occ".

Only works for 2 atoms at same site and both must be adjacent in the xyz file.
